### PR TITLE
Fix typo, perl-libwww is actually libwww-perl

### DIFF
--- a/README
+++ b/README
@@ -10,7 +10,7 @@ It supports a variety of different languages.
 Requirements
 ------------
 Perl         The Perl Programming Language
-perl-libwww  The World-Wide Web library for Perl
+libwww-perl  The World-Wide Web library for Perl
 sox          Sound eXchange, sound processing program
 mpg123       MPEG Audio Player and decoder
 Internet access in order to contact google and get the voice data.


### PR DESCRIPTION
There was an error in the README regarding the required libraries.
